### PR TITLE
test: wip: add wrapper script to give pytest correct env vars

### DIFF
--- a/tutor/templates/build/openedx/bin/pytest
+++ b/tutor/templates/build/openedx/bin/pytest
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ -z $(pip freeze | grep pytest) ] ; then
+	echo 'error: pytest is not installed into the Python virtualenv' &>2
+	echo 'Perhaps you are trying to run tests with `tutor local` or `tutor k8s` instead of `tutor dev`?'
+	exit 1
+fi
+
+exec /openedx/venv/bin/pytest
+


### PR DESCRIPTION
this is an older attempt at https://github.com/openedx/wg-developer-experience/issues/48 that I'm PRing just to preserve the diff