### PR TITLE
feat: use entrypoint to automatically pip-install mounted edx-platform 

### DIFF
--- a/changelog.d/20230111_135800_kdmc_egg_info_entrypoint.md
+++ b/changelog.d/20230111_135800_kdmc_egg_info_entrypoint.md
@@ -1,0 +1,13 @@
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+  of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+  the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+
+- [Improvement] It is no longer necessary to pip-install any requirements after bind-mounting a local copy of edx-platform (by @kdmccormick).

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -211,9 +211,6 @@ Then, you should run the following commands::
     # Run bash in the lms container
     tutor dev run --mount=/path/to/edx-platform lms bash
 
-    # Compile local python requirements
-    pip install --requirement requirements/edx/development.txt
-
     # Install nodejs packages in node_modules/
     npm clean-install
 

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -210,6 +210,7 @@ ENV DJANGO_SETTINGS_MODULE lms.envs.tutor.production
 {{ patch("openedx-dockerfile") }}
 
 EXPOSE 8000
+ENTRYPOINT ["set-up-and-run"]
 
 ###### Intermediate image with dev/test dependencies
 FROM production as development

--- a/tutor/templates/build/openedx/bin/set-up-and-run
+++ b/tutor/templates/build/openedx/bin/set-up-and-run
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Entrypoint script for the openedx image.
+# When a command is run from the openedx image, e.g.:
+#    tutor local run lms ./manage.py lms migrate
+# It actually goes through this script:
+#    set-up-and-run ./manage.py lms migrate
+
+# When a local copy of edx-platform is bind-mounted, its
+# egg-info directory may be missing or out of date. (The
+# egg-info contains compiled Python entrypoint metadata, which
+# is used by XBlock, Django App Plugins, and console scripts.)
+# So, we regenerate egg-info by pip-installing this directory.
+# To avoid running pip-install from *every* new lms and cms
+# container, we only run it if the entrypoint metadata is missing
+# or outdated.
+ENTRY_POINTS_INFO=Open_edX.egg-info/entry_points.txt
+if [ ! -f "$ENTRY_POINTS_INFO" ] || [ "$ENTRY_POINTS_INFO" -ot setup.py ]; then
+	pip install -e .
+fi
+
+# Run all arguments as a command.
+"$@"


### PR DESCRIPTION
Implements "Option A" from https://github.com/openedx/wg-developer-experience/issues/152, specifically:


>A. **Entrypoint script**:
>   * Write an entrypoint script (we'll call it `set-up-and-run`). It should first do the `ensure-setup` thing. Then, it should run the arguments passed to it as a shell command.
>      * For example: `set-up-and-run ./manage.py lms runserver ...` would create the egg-info if necessary, and then pass control to `./manage.py ...`.
>   * Add this script to the /openedx/bin folder of the openedx-dev image.
>   * Set the openedx-dev image's ENTRYPOINT to `['set-up-and-run']`.
>   * Now, check that a mounted edx-platform can be run without needing to manually create the egg-info.
>   * Update the documentation to remove `pip install ....` from the mounted edx-platform setup steps.
> ...

You can compare this with Option B here: https://github.com/kdmccormick/tutor/pull/25