### PR TITLE
feat!: move legacy build out to a plugin

### DIFF
--- a/changelog.d/20240903_140541_crisgarta8_closed_connection.md
+++ b/changelog.d/20240903_140541_crisgarta8_closed_connection.md
@@ -1,0 +1,1 @@
+[Improvement] Fixes an issue which caused 502 errors by a premature closed connection by uwsgi, it also improves the handling of SIGTERM in docker and other uwsgi improvements (by @Ian2012).

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -130,6 +130,34 @@ The process for upgrading from one major release to the next works similarly to 
     tutor local upgrade --from=quince
     tutor local launch
 
+
+Running older releases of Open edX
+-------------------------------------
+
+Instructions for installing the appropriate Tutor version for older Open edX releases. Each command ensures compatibility between Open edX and its corresponding Tutor version. For more details on versioning conventions in Tutor, see the :ref:`versioning` section.
+
++-------------------+---------------+--------------------------------------------+
+| Open edX Release  | Tutor version | Installation command                       |
++===================+===============+============================================+
+| Juniper           | v10           | pip install 'tutor[full]>=10.0.0,<11.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Koa               | v11           | pip install 'tutor[full]>=11.0.0,<12.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Lilac             | v12           | pip install 'tutor[full]>=12.0.0,<13.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Maple             | v13           | pip install 'tutor[full]>=13.0.0,<14.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Nutmeg            | v14           | pip install 'tutor[full]>=14.0.0,<15.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Olive             | v15           | pip install 'tutor[full]>=15.0.0,<16.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Palm              | v16           | pip install 'tutor[full]>=16.0.0,<17.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Quince            | v17           | pip install 'tutor[full]>=17.0.0,<18.0.0'  |
++-------------------+---------------+--------------------------------------------+
+| Redwood           | v18           | pip install 'tutor[full]>=18.0.0,<19.0.0'  |
++-------------------+---------------+--------------------------------------------+
+
 .. _autocomplete:
 
 Shell autocompletion

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -191,35 +191,12 @@ ENV REVISION_CFG=/openedx/config/revisions.yml
 COPY --chown=app:app settings/lms/*.py ./lms/envs/tutor/
 COPY --chown=app:app settings/cms/*.py ./cms/envs/tutor/
 
-# Pull latest translations via atlas
-RUN make clean_translations
-RUN ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
-RUN ./manage.py lms --settings=tutor.i18n pull_xblock_translations --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
-RUN atlas pull --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }} \
-    translations/edx-platform/conf/locale:conf/locale \
-    translations/studio-frontend/src/i18n/messages:conf/plugins-locale/studio-frontend
-RUN ./manage.py lms --settings=tutor.i18n compile_xblock_translations
-RUN ./manage.py cms --settings=tutor.i18n compile_xblock_translations
-RUN ./manage.py lms --settings=tutor.i18n compile_plugin_translations
-RUN ./manage.py lms --settings=tutor.i18n compilemessages -v1
-RUN ./manage.py lms --settings=tutor.i18n compilejsi18n
-RUN ./manage.py cms --settings=tutor.i18n compilejsi18n
-
 # Copy scripts
 COPY --chown=app:app ./bin /openedx/bin
 RUN chmod a+x /openedx/bin/*
 ENV PATH=/openedx/bin:${PATH}
 
 {{ patch("openedx-dockerfile-pre-assets") }}
-
-# Collect assets for the production image, de-duping assets with symlinks.
-# This includes static assets from 3rd party packages, such as Django admin.
-# If the tutor-legacyfrontends plugin is enabled, then this will also collect
-# the CSS & JS bundles produced by the edx-platform frontend build.
-RUN ./manage.py lms collectstatic --noinput --settings=tutor.assets && \
-    ./manage.py cms collectstatic --noinput --settings=tutor.assets && \
-    # De-duplicate static assets with symlinks \
-    rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/
 
 # Create a data directory, which might be used (or not)
 RUN mkdir /openedx/data
@@ -280,6 +257,29 @@ CMD ["./manage.py", "$SERVICE_VARIANT", "runserver", "0.0.0.0:8000"]
 
 ###### Final image with production cmd
 FROM production AS final
+
+# Pull latest translations via atlas
+RUN make clean_translations
+RUN ./manage.py lms --settings=tutor.i18n pull_plugin_translations --verbose --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
+RUN ./manage.py lms --settings=tutor.i18n pull_xblock_translations --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }}
+RUN atlas pull --repository='{{ ATLAS_REPOSITORY }}' --revision='{{ ATLAS_REVISION }}' {{ ATLAS_OPTIONS }} \
+    translations/edx-platform/conf/locale:conf/locale \
+    translations/studio-frontend/src/i18n/messages:conf/plugins-locale/studio-frontend
+RUN ./manage.py lms --settings=tutor.i18n compile_xblock_translations
+RUN ./manage.py cms --settings=tutor.i18n compile_xblock_translations
+RUN ./manage.py lms --settings=tutor.i18n compile_plugin_translations
+RUN ./manage.py lms --settings=tutor.i18n compilemessages -v1
+RUN ./manage.py lms --settings=tutor.i18n compilejsi18n
+RUN ./manage.py cms --settings=tutor.i18n compilejsi18n
+
+# Collect assets for the production image, de-duping assets with symlinks.
+# This includes static assets from 3rd party packages, such as Django admin.
+# If the tutor-legacyfrontends plugin is enabled, then this will also collect
+# the CSS & JS bundles produced by the edx-platform frontend build.
+RUN ./manage.py lms collectstatic --noinput --settings=tutor.assets && \
+    ./manage.py cms collectstatic --noinput --settings=tutor.assets && \
+    # De-duplicate static assets with symlinks \
+    rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/
 
 # Default amount of uWSGI processes
 ENV UWSGI_WORKERS=2

--- a/tutor/templates/build/openedx/Dockerfile
+++ b/tutor/templates/build/openedx/Dockerfile
@@ -212,18 +212,10 @@ ENV PATH=/openedx/bin:${PATH}
 
 {{ patch("openedx-dockerfile-pre-assets") }}
 
-# Build & collect production assets. By default, only assets from the default theme
-# will be processed. This makes the docker image lighter and faster to build.
-RUN npm run postinstall  # Postinstall artifacts are stuck in nodejs-requirements layer. Create them here too.
-RUN npm run compile-sass -- --skip-themes
-RUN npm run webpack
-
-# Now that the default theme is built, build any custom themes
-COPY --chown=app:app ./themes/ /openedx/themes
-RUN npm run compile-sass -- --skip-default
-
-# and finally, collect assets for the production image,
-# de-duping assets with symlinks.
+# Collect assets for the production image, de-duping assets with symlinks.
+# This includes static assets from 3rd party packages, such as Django admin.
+# If the tutor-legacyfrontends plugin is enabled, then this will also collect
+# the CSS & JS bundles produced by the edx-platform frontend build.
 RUN ./manage.py lms collectstatic --noinput --settings=tutor.assets && \
     ./manage.py cms collectstatic --noinput --settings=tutor.assets && \
     # De-duplicate static assets with symlinks \
@@ -278,13 +270,6 @@ ENV PYTHONBREAKPOINT=ipdb.set_trace
 # Point unit tests at the MongoDB container
 ENV EDXAPP_TEST_MONGO_HOST={{ MONGODB_HOST }}
 ENV EDXAPP_TEST_MONGO_PORT_NUM={{ MONGODB_PORT }}
-
-# Recompile static assets: in development mode all static assets are stored in edx-platform,
-# and the location of these files is stored in webpack-stats.json. If we don't recompile
-# static assets, then production assets will be served instead.
-RUN rm -r /openedx/staticfiles && \
-    mkdir /openedx/staticfiles && \
-    npm run build-dev
 
 {{ patch("openedx-dev-dockerfile-post-python-requirements") }}
 

--- a/tutor/templates/build/openedx/settings/uwsgi.ini
+++ b/tutor/templates/build/openedx/settings/uwsgi.ini
@@ -8,3 +8,16 @@ processes = $(UWSGI_WORKERS)
 thunder-lock = true
 single-interpreter = true
 enable-threads = true
+# Fix 502 errors for closed connections
+http-keepalive = 1
+add-header = Connection: Keep-Alive
+# Better startup/shutdown in docker:
+die-on-term = true
+lazy-apps = false
+need-app = true
+no-defer-accept = true
+# Enable the master process for performance
+master = true
+# Clean up settings
+py-call-osafterfork = true
+vacuum = true


### PR DESCRIPTION
Moves legacy frontends to a new plugin: https://github.com/kdmccormick/tutor-legacyfrontends (the interesting lines: https://github.com/kdmccormick/tutor-legacyfrontends/blob/master/tutorlegacyfrontends/plugin.py#L14-L55)

This plugin would be enabled by default, but developers could disable it in order to seriously speed up their image builds.